### PR TITLE
Add Steam gift card popup gimmick for property CTA buttons

### DIFF
--- a/docs/ASSESSMENT.md
+++ b/docs/ASSESSMENT.md
@@ -51,6 +51,7 @@
 - Uses a bento-style gallery that auto-fills to five tiles and plays nicely with local images.
 - Shows rich property details (amenities, policies, schedule) styled after Flex Living’s public marketing pages.
 - `ApprovedReviews` component fetches the same API, applies the persisted approval state, sorts descending by date, and renders only the selected reviews inside the property layout.
+- Easter egg alert: the primary property page buttons hide a playful surprise—give them a click and enjoy the message.
 
 ## Google Reviews Exploration
 - Investigated Google Places API for server-side ingestion. Viable options require enabling the **Places API** and using the **Place Details** endpoint with `reviews` fields.

--- a/src/app/property/[slug]/page.tsx
+++ b/src/app/property/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import ApprovedReviews from "@/components/ApprovedReviews";
+import GiftCardButton from "@/components/GiftCardButton";
 import MagicBentoGallery from "@/components/MagicBentoGallery";
 import { getPropertyBySlug } from "@/lib/properties";
 import type { ReactElement } from "react";
@@ -519,12 +520,15 @@ export default async function PropertyPage({ params }: Props) {
                   </div>
                 </fieldset>
                 <div className="space-y-3">
-                  <button type="submit" className="w-full rounded-2xl bg-[#134e48] px-4 py-3 text-center text-base font-semibold text-white shadow-lg shadow-[#134e4830] transition hover:bg-[#0f403b]">
+                  <GiftCardButton
+                    type="submit"
+                    className="w-full rounded-2xl bg-[#134e48] px-4 py-3 text-center text-base font-semibold text-white shadow-lg shadow-[#134e4830] transition hover:bg-[#0f403b]"
+                  >
                     Check availability
-                  </button>
-                  <button type="button" className="w-full rounded-2xl border border-[#134e48] px-4 py-3 text-center text-base font-semibold text-[#134e48] transition hover:bg-[#ecf4ef]">
+                  </GiftCardButton>
+                  <GiftCardButton className="w-full rounded-2xl border border-[#134e48] px-4 py-3 text-center text-base font-semibold text-[#134e48] transition hover:bg-[#ecf4ef]">
                     Send inquiry
-                  </button>
+                  </GiftCardButton>
                 </div>
                 <label className="flex items-center gap-3 rounded-2xl bg-[#f1f6f2] px-4 py-3 text-sm text-[#536156]">
                   <span className="relative inline-flex h-5 w-9 items-center">
@@ -540,9 +544,9 @@ export default async function PropertyPage({ params }: Props) {
             <div className="rounded-3xl border border-[#e2e6db] bg-[#f8faf6] p-6 text-center shadow-sm">
               <h3 className="text-lg font-semibold text-[#13392f]">Need help planning?</h3>
               <p className="mt-2 text-sm text-[#5f6f65]">Our concierge team can arrange transport, private chefs, and more.</p>
-              <button type="button" className="mt-4 inline-flex items-center justify-center rounded-full border border-[#134e48] px-5 py-2 text-sm font-semibold text-[#134e48] transition hover:bg-[#ecf4ef]">
+              <GiftCardButton className="mt-4 inline-flex items-center justify-center rounded-full border border-[#134e48] px-5 py-2 text-sm font-semibold text-[#134e48] transition hover:bg-[#ecf4ef]">
                 Contact concierge
-              </button>
+              </GiftCardButton>
             </div>
           </aside>
         </div>

--- a/src/app/property/[slug]/page.tsx
+++ b/src/app/property/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import ApprovedReviews from "@/components/ApprovedReviews";
+import AvailabilityConfirmationButton from "@/components/AvailabilityConfirmationButton";
 import GiftCardButton from "@/components/GiftCardButton";
 import MagicBentoGallery from "@/components/MagicBentoGallery";
 import { getPropertyBySlug } from "@/lib/properties";
@@ -520,12 +521,12 @@ export default async function PropertyPage({ params }: Props) {
                   </div>
                 </fieldset>
                 <div className="space-y-3">
-                  <GiftCardButton
-                    type="submit"
+                  <AvailabilityConfirmationButton
                     className="w-full rounded-2xl bg-[#134e48] px-4 py-3 text-center text-base font-semibold text-white shadow-lg shadow-[#134e4830] transition hover:bg-[#0f403b]"
+                    confirmationClassName="text-center"
                   >
                     Check availability
-                  </GiftCardButton>
+                  </AvailabilityConfirmationButton>
                   <GiftCardButton className="w-full rounded-2xl border border-[#134e48] px-4 py-3 text-center text-base font-semibold text-[#134e48] transition hover:bg-[#ecf4ef]">
                     Send inquiry
                   </GiftCardButton>

--- a/src/components/AvailabilityConfirmationButton.tsx
+++ b/src/components/AvailabilityConfirmationButton.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState, type ComponentProps } from "react";
+
+import GiftCardButton from "./GiftCardButton";
+
+type GiftCardButtonProps = ComponentProps<typeof GiftCardButton>;
+
+type AvailabilityConfirmationButtonProps = GiftCardButtonProps & {
+  confirmationText?: string;
+  confirmationClassName?: string;
+};
+
+export default function AvailabilityConfirmationButton({
+  confirmationText = "Availability confirmed",
+  confirmationClassName,
+  type = "submit",
+  onClick,
+  ...buttonProps
+}: AvailabilityConfirmationButtonProps) {
+  const [isConfirmed, setIsConfirmed] = useState(false);
+
+  return (
+    <div className="space-y-2">
+      <GiftCardButton
+        {...buttonProps}
+        type={type}
+        onClick={(event) => {
+          setIsConfirmed(true);
+          onClick?.(event);
+        }}
+      />
+      {isConfirmed ? (
+        <p
+          className={`text-sm font-semibold text-[#134e48] ${confirmationClassName ?? ""}`.trim()}
+          role="status"
+          aria-live="polite"
+        >
+          {confirmationText}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/GiftCardButton.tsx
+++ b/src/components/GiftCardButton.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { type ButtonHTMLAttributes, type MouseEvent } from "react";
+
+const defaultMessage = "Send me a $100 Steam gift card to make this functional.";
+
+type GiftCardButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  message?: string;
+};
+
+export default function GiftCardButton({
+  message = defaultMessage,
+  onClick,
+  type = "button",
+  children,
+  ...buttonProps
+}: GiftCardButtonProps) {
+  function handleClick(event: MouseEvent<HTMLButtonElement>) {
+    if (type === "submit") {
+      event.preventDefault();
+    }
+
+    window.alert(message);
+    onClick?.(event);
+  }
+
+  return (
+    <button {...buttonProps} type={type} onClick={handleClick}>
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce a reusable GiftCardButton client component that presents a playful Steam gift card alert
- swap property call-to-action buttons to use the new component for the requested gimmick

## Testing
- npm run lint *(passes with existing unused variable warnings in the reviews API route)*

------
https://chatgpt.com/codex/tasks/task_e_68d209f172c48320aa389f882c913ead