### PR TITLE
Fix average rating column alignment in reviews table

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -211,6 +211,7 @@ input[type="checkbox"]{ accent-color: var(--accent); }
   padding:.75rem 1rem;
   border-bottom:1px solid var(--border);
 }
+.summary-table thead th.text-right{ text-align:right; }
 
 .summary-table tbody td{
   padding:1rem;


### PR DESCRIPTION
## Summary
- allow the Average rating column header to respect the `text-right` helper in the reviews summary table

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d22a872a748320ab154aab15b56b11