### PR TITLE
Fix Next.js build by removing TS import extensions

### DIFF
--- a/src/lib/google-service.ts
+++ b/src/lib/google-service.ts
@@ -7,9 +7,9 @@ import {
   parseGoogleMock,
   parseGooglePlaceResponse,
   type GoogleMockPlace,
-} from "./google.ts";
-import { properties } from "./properties.ts";
-import type { Review } from "./reviews.ts";
+} from "./google";
+import { properties } from "./properties";
+import type { Review } from "./reviews";
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const googleSeedPath = resolve(currentDir, "../../data/reviews.google.json");

--- a/src/lib/google.ts
+++ b/src/lib/google.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import type { Review } from "./reviews.ts";
+import type { Review } from "./reviews";
 
 const starRatingMap: Record<string, number> = {
   ONE: 1,

--- a/src/lib/hostaway-service.ts
+++ b/src/lib/hostaway-service.ts
@@ -8,9 +8,9 @@ import {
   parseHostawayPayload,
   summarizeReviews,
   type HostawayReview,
-} from "./hostaway.ts";
-import { loadGoogleReviews } from "./google-service.ts";
-import type { Review, ReviewSummary } from "./reviews.ts";
+} from "./hostaway";
+import { loadGoogleReviews } from "./google-service";
+import type { Review, ReviewSummary } from "./reviews";
 
 const tokenResponseSchema = z.object({
   access_token: z.string().optional(),

--- a/src/lib/hostaway.ts
+++ b/src/lib/hostaway.ts
@@ -4,7 +4,7 @@ import {
   calculateAverageRating,
   type Review,
   type ReviewSummary,
-} from "./reviews.ts";
+} from "./reviews";
 
 export const ratingValueSchema = z
   .union([z.number(), z.string(), z.null(), z.undefined()])

--- a/tests/google-service.test.ts
+++ b/tests/google-service.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { loadGoogleReviews } from "../src/lib/google-service.ts";
+import { loadGoogleReviews } from "../src/lib/google-service";
 
 test("loadGoogleReviews falls back to mock data when API disabled", async () => {
   const { reviews, meta } = await loadGoogleReviews();

--- a/tests/hostaway-route.test.ts
+++ b/tests/hostaway-route.test.ts
@@ -5,8 +5,8 @@ import {
   normalizeHostawayReview,
   summarizeReviews,
   type HostawayReview,
-} from "../src/lib/hostaway.ts";
-import { loadHostawayReviews } from "../src/lib/hostaway-service.ts";
+} from "../src/lib/hostaway";
+import { loadHostawayReviews } from "../src/lib/hostaway-service";
 
 test("normalizeHostawayReview derives rating from category scores", () => {
   const review: HostawayReview = {

--- a/tests/reviews-helpers.test.ts
+++ b/tests/reviews-helpers.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { calculateAverageRating } from "../src/lib/reviews.ts";
+import { calculateAverageRating } from "../src/lib/reviews";
 
 test("calculateAverageRating ignores unrated entries", () => {
   const result = calculateAverageRating(


### PR DESCRIPTION
## Summary
- update internal TypeScript imports to omit the .ts extension for compatibility with Next.js
- adjust associated test files to match the new module specifiers

## Testing
- npm run lint
- npm run build *(fails: Turbopack cannot fetch Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d22d24a1f083208b1276d1b0d2958f